### PR TITLE
added the authSource configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -514,7 +514,7 @@ exports.connect = function(config, intern, callback) {
 
   mongoString += host + '/' + config.database;
 
-  if(config.authSource !== undefined) {
+  if(config.authSource !== undefined && config.user !== undefined && config.password !== undefined) {
     mongoString += '/?authSource=' + config.authSource;
   }
 

--- a/index.js
+++ b/index.js
@@ -514,6 +514,10 @@ exports.connect = function(config, intern, callback) {
 
   mongoString += host + '/' + config.database;
 
+  if(config.authdb !== undefined) {
+    mongoString += '/?authSource=' + config.authdb;
+  }
+
   db = config.db || new MongoClient(new Server(host, port));
   callback(null, new MongodbDriver(db, intern, mongoString));
 };

--- a/index.js
+++ b/index.js
@@ -514,8 +514,8 @@ exports.connect = function(config, intern, callback) {
 
   mongoString += host + '/' + config.database;
 
-  if(config.authdb !== undefined) {
-    mongoString += '/?authSource=' + config.authdb;
+  if(config.authSource !== undefined) {
+    mongoString += '/?authSource=' + config.authSource;
   }
 
   db = config.db || new MongoClient(new Server(host, port));


### PR DESCRIPTION
we want to support the [authSource ](https://docs.mongodb.org/manual/reference/connection-string/) connection option o mongodb from configuration

Specify the database name associated with the user’s credentials, if the users collection do not exist in the database where the client is connecting. authSource defaults to the database specified in the connection string.
