### PR TITLE
add update to _run internal

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,7 +345,7 @@ var MongodbDriver = Base.extend({
             db.db(collection, callbackFunction);
             break;
           case 'update':
-            db[command](collection, options, callbackFunction);
+            db.collection(collection)[command](options.query, options.update, options.options, callbackFunction);
             break;
           default:
             db[command](collection, callbackFunction);

--- a/index.js
+++ b/index.js
@@ -344,6 +344,9 @@ var MongodbDriver = Base.extend({
           case 'use':
             db.db(collection, callbackFunction);
             break;
+          case 'update':
+            db[command](collection, options, callbackFunction);
+            break;
           default:
             db[command](collection, callbackFunction);
             break;


### PR DESCRIPTION
In mongodb I was able to do the following:
`db.users.update( {}, { $rename: { 'permissions': 'accesses' } }, { upsert: false, multi: true } )`

For the migration I had to add the `update` implementation to the mongo-handling. Now I can do:
```javascript

  db._run('update', 'users', {
      query: {},
      update: { $rename: { 'permissions': 'accesses' } },
      options: { upsert: false, multi: true }
    }, 
    callback()
  );
```