### PR TITLE
ADD: removeMany case to _run function

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,12 +325,11 @@ var MongodbDriver = Base.extend({
             else
               db.collection(collection).insertOne(options, {}, callbackFunction);
             break;
+          case 'removeMany':
+            db.collection(collection).deleteMany(options, callbackFunction);
+            break;
           case 'remove':
-            // options is the records to insert in this case
-            if(util.isArray(options))
-              db.collection(collection).deleteMany(options, callbackFunction);
-            else
-              db.collection(collection).deleteOne(options, callbackFunction);
+            db.collection(collection).deleteOne(options, callbackFunction);
             break;
           case 'collections':
             db.collections(callbackFunction);


### PR DESCRIPTION
I couldn't delete multiple documents. I know `_run` is private, but still thought it would be helpful to suggest to fix it:

If you had run till now with something like:
`db._run('remove', 'collectionName', { myKey: 'string' });`
 you couldn't remove many documents.

 The code to delete many implied to use it as:
`db._run('remove', 'collectionName', [{ myKey: 'string' }]);` (check for `util.isArray(options)`)
but that would throw an error [1].

To keep current code running and not to break stuff I introduced the `removeMany`:
`db._run('removeMany', 'collectionName', { myKey: 'string' })`

1: [db.collection.deleteMany()](https://docs.mongodb.com/manual/reference/method/db.collection.deleteMany/)

What do you think? Or did you have an other idea when you checked for `util.isArray(options)`? 