### PR TITLE
support ssl config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,6 +517,10 @@ exports.connect = function(config, intern, callback) {
 
   mongoString += host + '/' + config.database;
 
+  if (config.ssl) {
+    mongoString += '?ssl=true';
+  }
+
   db = config.db || new MongoClient(new Server(host, port));
   callback(null, new MongodbDriver(db, intern, mongoString));
 };


### PR DESCRIPTION
Correct me if there's another way to connect to a mongo instance w ssl - I had to enable it this way.