### PR TITLE
Fleshed out update function

### DIFF
--- a/index.js
+++ b/index.js
@@ -429,9 +429,18 @@ var MongodbDriver = Base.extend({
     return Promise.reject('There is no NoSQL implementation yet!');
   },
 
-  update: function() {
-
-    return Promise.reject('There is no NoSQL implementation yet!');
+  /**
+   * Update a record(s) of a collection
+   * @param collectionName  - The collection to update
+   * @param query           - The record(s) to update
+   * @param update          - The update
+   * @param options
+   * @param callback
+     * @returns {*}
+     */
+  update: function(collectionName, query, update, options, callback) {
+    return this._run('update', collectionName, {query: query, update: update, options: options})
+      .nodeify(callback);
   }
 });
 


### PR DESCRIPTION
My attempt at completing the update function so that the usage is somewhat in line with the docs (https://db-migrate.readthedocs.io/en/latest/Getting%20Started/usage/#update-table-data-searchclauseid).

However usage looks more like:
```
exports.up = function(db, callback) {
  return db.update('users', { roles: ['guest'] }, { $set: {roles: ['admin']} }, {}, callback);
};
```