### PR TITLE
Support ReplicaSet config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,9 +517,17 @@ exports.connect = function(config, intern, callback) {
 
   mongoString += host + '/' + config.database;
 
+  extraParams = [];
   if (config.ssl) {
-    mongoString += '?ssl=true';
+    extraParams.push('ssl=true');
   }
+  if (config.replicaSet){
+    extraParams.push('replicaSet=' + config.replicaSet);
+  }
+  if(extraParams.length > 0){
+      mongoString += '?' + extraParams.join('&');
+  }
+
 
   db = config.db || new MongoClient(new Server(host, port));
   callback(null, new MongodbDriver(db, intern, mongoString));


### PR DESCRIPTION
node-mongodb-native@2.1.19 implement a new connection string format for Replica Set connections.