### PR TITLE
Support for empty environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,11 +493,11 @@ exports.connect = function(config, intern, callback) {
   type = internals.mod.type;
 
   // Make sure the database is defined
-  if(config.database === undefined) {
+  if(!config.database) {
     throw new Error('database must be defined in database.json');
   }
 
-  if(config.port === undefined) {
+  if(!config.port) {
     port = 27017;
   } else {
     port = config.port;
@@ -505,7 +505,7 @@ exports.connect = function(config, intern, callback) {
 
   config.host = util.isArray(config.hosts) ? config.hosts : config.host;
 
-  if(config.host === undefined) {
+  if(!config.host) {
 
     host = 'localhost' + ':' + port;
   } else if(util.isArray(config.host) ) {
@@ -524,7 +524,7 @@ exports.connect = function(config, intern, callback) {
 
   var mongoString = 'mongodb://';
 
-  if(config.user !== undefined && config.password !== undefined) {
+  if(config.user && config.password) {
     mongoString += config.user + ':' + config.password + '@';
   }
 
@@ -535,7 +535,7 @@ exports.connect = function(config, intern, callback) {
     extraParams.push('ssl=true');
   }
 
-  if(config.authSource !== undefined && config.user !== undefined && config.password !== undefined) {
+  if(config.authSource && config.user && config.password) {
     extraParams.push('authSource=' + config.authSource);
   }
 


### PR DESCRIPTION
Hello.

I have a problem with **empty environment variables**.

For example, if `user` and `password` are defined into `.env` file, but empty (default credentials for Docker MongoDB image), the target `mongoString` will be `mongodb://:@HOST:PORT/DATABASE` and fails by calling `mongodb` module.

`.env`:
```json
...
MONGO_USER=
MONGO_PASSWORD=
```

`config.json`:
```json
{
  "dev": {
    "driver": "mongodb",
    ...
    "user": {"ENV": "MONGO_USER"},
    "password": {"ENV": "MONGO_PASSWORD"}
  },
}
```

If we use additional *environment key* (like `dev` and `prod`) to distinguate environments, the solution is to don't define entries into `config.json` corresponding environment. Ok.
But *for me* it's better to minimize configuration and **use only environment variables to distinguate environments**. So in this case we encounter this problem.

This pull-request allow support for this behaviour.

Thanks.