### PR TITLE
Feature: Allow to pass additional options for run('createIndex')

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ var MongodbDriver = Base.extend({
     var parameters = {
       columns: columns,
       options: {
-          indexName: indexName,
+          name: indexName,
           unique: unique
       }
     };


### PR DESCRIPTION
Hey!

It allow us to do (pass advanced options for `createIndex`)

```javascript
await db._run('createIndex', 'user', {
        columns: 'login',
        options: {
            name: 'login_uniq',
            unique: true,
            partialFilterExpression: {
                status: {
                    $eq: [
                        'ACTIVE',
                        'BLOCKED'
                    ]
                }
            }
        }
});
```

Thanks