### PR TITLE
fix: allow special chars in password or user string

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,6 +525,10 @@ exports.connect = function(config, intern, callback) {
   var mongoString = 'mongodb://';
 
   if(config.user !== undefined && config.password !== undefined) {
+    // Ensure user and password can contain special characters like "@" so app doesn't throw an exception when connecting to MongoDB
+    config.user = encodeURIComponent(config.user);
+    config.password = encodeURIComponent(config.password);
+
     mongoString += config.user + ':' + config.password + '@';
   }
 


### PR DESCRIPTION
This commit fixes a bug where special chars like `$`, `*` or `^` would cause the library to crash

Signed-off-by: BorntraegerMarc <marc.borntraeger@gmail.com>