### PR TITLE
mongodb: use driver 4.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - 8
   - 10
+  - 14
+  - 16
   - node
 
 notifications:


### PR DESCRIPTION
Since this project is running on a old mongodb driver version, we should update it.
Will address issue #51 